### PR TITLE
chore: Update create2-helpers to work with new foundry

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,7 @@ bytecode_hash = "none"
 remappings = [
     "forge-std/=dependencies/forge-std-1.9.6/src/",
     "solady/=dependencies/solady-0.1.12/src/",
-    "create2-helpers/=dependencies/create2-helpers-0.4.0/src/",
+    "create2-helpers/=dependencies/create2-helpers-0.5.0/src/",
     "@openzeppelin-contracts/=dependencies/@openzeppelin-contracts-5.2.0/src/",
     "@openzeppelin-contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.2.0/",
     "@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.2.0/",
@@ -34,7 +34,7 @@ multline_func_header = "all"
 [dependencies]
 forge-std = "1.9.6"
 solady = "0.1.12"
-create2-helpers = "0.4.0"
+create2-helpers = "0.5.0"
 "@openzeppelin-contracts" = "5.2.0"
 "@openzeppelin-contracts-upgradeable" = "5.2.0"
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.20;
 
 import { BaseCreate2Script } from "create2-helpers/BaseCreate2Script.sol";
 import { Script, console2 } from "forge-std/Script.sol";
-import { console } from "forge-std/console.sol";
 import {
     MINIMAL_PROXY_OZ_ADDRESS,
     MINIMAL_PROXY_OZ_SALT,
@@ -19,16 +18,16 @@ import { MinimalUpgradeableProxySolady } from "src/MinimalUpgradeableProxySolady
 contract Deploy is BaseCreate2Script {
 
     function run() public {
-        console.log("ProxyFactory initcode hash:");
-        console.logBytes32(
+        console2.log("ProxyFactory initcode hash:");
+        console2.logBytes32(
             keccak256(abi.encodePacked(type(DeterministicProxyFactory).creationCode))
         );
-        console.log("MinimalUpgradeableProxySolady initcode hash:");
-        console.logBytes32(
+        console2.log("MinimalUpgradeableProxySolady initcode hash:");
+        console2.logBytes32(
             keccak256(abi.encodePacked(type(MinimalUpgradeableProxySolady).creationCode))
         );
-        console.log("MinimalUpgradeableProxyOZ initcode hash:");
-        console.logBytes32(
+        console2.log("MinimalUpgradeableProxyOZ initcode hash:");
+        console2.logBytes32(
             keccak256(abi.encodePacked(type(MinimalUpgradeableProxyOZ).creationCode))
         );
 
@@ -37,13 +36,15 @@ contract Deploy is BaseCreate2Script {
         for (uint256 i = 0; i < networks.length; i++) {
             rpcUrls[i] = getChain(networks[i]).rpcUrl;
         }
-        runOnNetworks(this._run, rpcUrls);
+        runOnNetworks(_run, rpcUrls);
     }
 
-    function _run() public {
+    function _run() internal {
+        console2.log("Deploying DeterministicProxyFactory");
         address proxyFactoryAddr = _create2IfNotDeployed(
             deployer, PROXY_FACTORY_SALT, type(DeterministicProxyFactory).creationCode
         );
+        console2.log("Deployed DeterministicProxyFactory to address:", proxyFactoryAddr);
         require(
             proxyFactoryAddr == PROXY_FACTORY_ADDRESS,
             "Deployed DeterministicProxyFactory to wrong address"

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -14,10 +14,10 @@ integrity = "498747bedc3f757976da0b6125d26a63e79bb2b4dbabd8ecd2547e809a2fa27e"
 
 [[dependencies]]
 name = "create2-helpers"
-version = "0.4.0"
-url = "https://soldeer-revisions.s3.amazonaws.com/create2-helpers/0_4_0_22-03-2025_01:31:56_create2-helpers.zip"
-checksum = "2693981e7f6ce53687f5b2bda8d63e6523d2b47427cfe746552a8848f6c20163"
-integrity = "3991c62c03ff7933891a99b2b5305eb86b73cba83c0acd88c120bd6ae75f741b"
+version = "0.5.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/create2-helpers/0_5_0_13-05-2025_17:05:02_create2-helpers.zip"
+checksum = "2e68e7866282a2801318145d610ea6f8bc64f5a591e1b57a27dd7d49b7adad65"
+integrity = "a18fe8aa906f2840378580388d61d032095410791ce6dff1f9a86754a6755d44"
 
 [[dependencies]]
 name = "forge-std"


### PR DESCRIPTION
New Forge behavior is to revert when `address(this)` is invoked. This is configurable, but decided to change interface of `create2-helpers` and update the package.

https://github.com/foundry-rs/foundry/pull/10295