### PR TITLE
feat: add more-minimal proxy

### DIFF
--- a/src/MinimalUUPSUpgradeableUnsafeInitialUpgrade.sol
+++ b/src/MinimalUUPSUpgradeableUnsafeInitialUpgrade.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import { UUPSUpgradeable } from "solady/utils/UUPSUpgradeable.sol";
+
+/**
+ * @title  MinimalUUPSUpgradeableUnsafeInitialUpgrade
+ * @author emo.eth
+ * @notice A minimal UUPSUpgradeable implementation using Solady's UUPSUpgradeable.
+ *         WARNING: This contract implements no initializers or ownable interface.
+ *         The upgrade is not gated to an owner. It must be deployed **and upgraded**
+ *         atomically. The upgrade process should initialize the contract and override the
+ *         _authorizeUpgrade function to be permissioned.
+ */
+contract MinimalUUPSUpgradeableUnsafeInitialUpgrade is UUPSUpgradeable {
+
+    constructor() {
+        // no initializers to disable
+    }
+
+    /**
+     * @notice WARNING: The upgrade is not gated to owner; it must be deployed **and upgraded**
+     * atomically; the upgrade process must initialize the contract and override this function to be
+     * permissioned.
+     */
+    function _authorizeUpgrade(address newImplementation) internal override { }
+
+}

--- a/test/MinimalUUPSUpgradeableUnsafeInitialUpgrade.t.sol
+++ b/test/MinimalUUPSUpgradeableUnsafeInitialUpgrade.t.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { Test } from "forge-std/Test.sol";
+
+import { LibClone } from "solady/utils/LibClone.sol";
+import { MinimalUUPSUpgradeableUnsafeInitialUpgrade } from
+    "src/MinimalUUPSUpgradeableUnsafeInitialUpgrade.sol";
+
+// Mock implementation for testing
+contract MockUpgradeableUnsafe is MinimalUUPSUpgradeableUnsafeInitialUpgrade {
+
+    uint256 public counter;
+
+    function increment() public {
+        counter++;
+    }
+
+    function someFunction() public pure returns (string memory) {
+        return "hello";
+    }
+
+}
+
+contract MinimalUUPSUpgradeableUnsafeInitialUpgradeTest is Test {
+
+    address implementation;
+    address proxy;
+
+    function setUp() public {
+        implementation = address(new MinimalUUPSUpgradeableUnsafeInitialUpgrade());
+    }
+
+    function test_implementationCannotBeUpgraded() public {
+        // Deploy the implementation contract directly (not as a proxy)
+        MinimalUUPSUpgradeableUnsafeInitialUpgrade impl =
+            new MinimalUUPSUpgradeableUnsafeInitialUpgrade();
+
+        // Try to call upgradeToAndCall on the implementation directly
+        // This should fail because the implementation is not a proxy
+        address newImplementation = address(0x123);
+        bytes memory data = "";
+
+        // The call should revert because the implementation contract itself is not a proxy
+        // and doesn't have the proxy storage layout
+        vm.expectRevert();
+        MinimalUUPSUpgradeableUnsafeInitialUpgrade(address(impl)).upgradeToAndCall(
+            newImplementation, data
+        );
+    }
+
+    function test_implementationCannotBeUpgradedWithData() public {
+        // Deploy the implementation contract directly (not as a proxy)
+        MinimalUUPSUpgradeableUnsafeInitialUpgrade impl =
+            new MinimalUUPSUpgradeableUnsafeInitialUpgrade();
+
+        // Try to call upgradeToAndCall with some data
+        address newImplementation = address(0x123);
+        bytes memory data = abi.encodeWithSignature("someFunction()");
+
+        // The call should revert because the implementation contract itself is not a proxy
+        vm.expectRevert();
+        MinimalUUPSUpgradeableUnsafeInitialUpgrade(address(impl)).upgradeToAndCall(
+            newImplementation, data
+        );
+    }
+
+    function test_implementationCannotBeUpgradedByAnyone() public {
+        // Deploy the implementation contract directly (not as a proxy)
+        MinimalUUPSUpgradeableUnsafeInitialUpgrade impl =
+            new MinimalUUPSUpgradeableUnsafeInitialUpgrade();
+
+        // Try to call upgradeToAndCall from a different address
+        address attacker = address(0x456);
+        address newImplementation = address(0x123);
+        bytes memory data = "";
+
+        vm.prank(attacker);
+        // The call should revert because the implementation contract itself is not a proxy
+        vm.expectRevert();
+        MinimalUUPSUpgradeableUnsafeInitialUpgrade(address(impl)).upgradeToAndCall(
+            newImplementation, data
+        );
+    }
+
+    function test_proxiableUUIDReturnsCorrectSlot() public {
+        // Deploy the implementation contract directly
+        MinimalUUPSUpgradeableUnsafeInitialUpgrade impl =
+            new MinimalUUPSUpgradeableUnsafeInitialUpgrade();
+
+        // The proxiableUUID should return the ERC1967 implementation slot
+        bytes32 expectedSlot = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+        assertEq(impl.proxiableUUID(), expectedSlot);
+    }
+
+    function test_proxyCanBeUpgradedByAnyone() public {
+        // Deploy a proxy using the implementation
+        proxy = LibClone.deployERC1967(address(implementation));
+
+        // Create a new implementation to upgrade to
+        address newImplementation = address(new MinimalUUPSUpgradeableUnsafeInitialUpgrade());
+        bytes memory data = "";
+
+        // Anyone should be able to upgrade the proxy since _authorizeUpgrade is empty
+        address randomUser = address(0x789);
+        vm.prank(randomUser);
+
+        // This should succeed because the proxy can be upgraded by anyone
+        MinimalUUPSUpgradeableUnsafeInitialUpgrade(proxy).upgradeToAndCall(newImplementation, data);
+    }
+
+    function test_proxyCanBeUpgradedByAnyoneWithData() public {
+        // Deploy a proxy using the implementation
+        proxy = LibClone.deployERC1967(address(implementation));
+
+        // Create a new mock implementation to upgrade to
+        address newImplementation = address(new MockUpgradeableUnsafe());
+        bytes memory data = abi.encodeWithSignature("increment()");
+
+        // Anyone should be able to upgrade the proxy since _authorizeUpgrade is empty
+        address randomUser = address(0x789);
+        vm.prank(randomUser);
+
+        // This should succeed because the proxy can be upgraded by anyone
+        MinimalUUPSUpgradeableUnsafeInitialUpgrade(proxy).upgradeToAndCall(newImplementation, data);
+
+        // Verify the function was called
+        assertEq(MockUpgradeableUnsafe(proxy).counter(), 1);
+    }
+
+}


### PR DESCRIPTION
Previous minimal proxies must be deployed and upgraded by their initial owners, which can create awkward flows. 

The more-minimal proxy is less opinionated (no specific ownable or initializable implementations) and can be upgraded to any implementation, but the upgrade must initialize the destination with relevant auth accounts.